### PR TITLE
feat: add optional lation_ui support

### DIFF
--- a/modules/ShowNotification/client.lua
+++ b/modules/ShowNotification/client.lua
@@ -1,4 +1,5 @@
 local EnableOX = false -- Enable use of ox_lib for notifications if available
+local EnableLation = false -- Enable use of lation_ui for notifications if available
 
 --- Selects and returns the most appropriate notification function based on the current game setup.
 -- This function checks the available libraries and configurations to determine which notification method to use.
@@ -14,6 +15,15 @@ local Notification = function()
                 title = title,
                 description = message,
                 type = type or 'inform'
+            })
+        end
+    elseif EnableLation then
+        return function(message, type)
+            local title = SD.String.CapitalizeFirst(type or 'inform')
+            exports.lation_ui:notify({
+                title = title,
+                message = message,
+                type = type or 'info',
             })
         end
     else

--- a/modules/StartProgress/client.lua
+++ b/modules/StartProgress/client.lua
@@ -1,4 +1,5 @@
 local EnableOX = false -- Enable use of ox_lib for progressbars if available
+local EnableLation = false -- Enable use of lation_ui for progressbars if available
 
 --- Selects and returns the most appropriate function for starting a progress bar.
 -- This function determines the best method for displaying progress bars based on the current game setup
@@ -18,6 +19,21 @@ local ProgressBar = function()
             }) then 
                 completed()
             else 
+                notfinished()
+            end
+        end
+    elseif EnableLation then
+        return function(identifier, label, duration, completed, notfinished)
+            if exports.lation_ui:progressBar({
+                label = label,
+                duration = duration,
+                useWhileDead = false,
+                allowSwimming = true,
+                canCancel = true,
+                disable = { move = true }
+            }) then
+                completed()
+            else
                 notfinished()
             end
         end

--- a/modules/TextUI/client.lua
+++ b/modules/TextUI/client.lua
@@ -2,6 +2,7 @@
 SD.TextUI = {}
 
 local EnableOX = true -- Enable use of ox_lib for TextUI if available
+local EnableLation = false -- Enable use of lation_ui for TextUI if available
 local lastInteractionTime = 0
 
 -- Function to dynamically select the appropriate show and hide functions based on the current configuration.
@@ -11,6 +12,16 @@ local TextUI = function()
             lib.showTextUI(text, options)
         end, function()
             lib.hideTextUI()
+        end
+    elseif EnableLation then
+        return function(text, options)
+            exports.lation_ui:showText({
+                description = text,
+                icon = options.icon or nil,
+                position = options.position or nil,
+            })
+        end, function()
+            exports.lation_ui:hideText()
         end
     elseif GetResourceState('cd_drawtextui') == 'started' then
         return function(text)


### PR DESCRIPTION
Lil PR adding optional support for an upcoming `lation_ui` release - if this is better done manually by users of this lib - that is fine <3 just thought I'd submit this in case, figured any way to make it easier is always a big fat W

p.s - when register/show context menu modules ty qt 